### PR TITLE
Require 2 characters for searching

### DIFF
--- a/ui/src/app/place-search/place-search.service.ts
+++ b/ui/src/app/place-search/place-search.service.ts
@@ -27,6 +27,9 @@ export class PlaceSearchService {
   }
 
   public geocode(placeStr: string): Promise<Place[]> {
+    if (placeStr.trim().length <= 2) {
+      return Promise.resolve([]);
+    }
     return this.mapquestGeocode(placeStr)
       .then(mapquestPlaces => {
         return mapquestPlaces.map(mapquestPlace => {


### PR DESCRIPTION
With this change no empty query is sent anymore on page load.